### PR TITLE
adds c4.large u14 instance for testing drydock

### DIFF
--- a/rc-saas/sn-private-ship-builds.tf
+++ b/rc-saas/sn-private-ship-builds.tf
@@ -273,3 +273,28 @@ resource "aws_instance" "mohit_x86_64_u1604" {
 output "mohit_x86_64_u1604" {
   value = "${aws_instance.mohit_x86_64_u1604.private_ip}"
 }
+
+resource "aws_instance" "vishnu_x86_64_u1404" {
+  ami = "${var.ami_us_east_1_ubuntu1404}"
+  availability_zone = "${var.avl-zone}"
+  instance_type = "${var.in_type_ms}"
+  key_name = "${var.aws_key_name}"
+  subnet_id = "${aws_subnet.sn_public.id}"
+
+  vpc_security_group_ids = [
+    "${aws_security_group.sg_private_ship_builds.id}"]
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 50
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "vishnu_x86_64_u1404_${var.install_version}"
+  }
+}
+
+output "vishnu_x86_64_u1404" {
+  value = "${aws_instance.vishnu_x86_64_u1404.private_ip}"
+}


### PR DESCRIPTION
https://github.com/Shippable/infra/issues/502

I have been trying to build the drydock/u14phpall image on t2.medium, but it seems to fail with memory allocation error.

So requesting for the machine which has the same configuration as the build node ( c4.large ).