### PR TITLE
add new, bigger machine for rc onebox

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -97,9 +97,9 @@ apply_changes() {
   echo "-----------------------------------"
   terraform --version
   terraform plan -var-file="$RES_AWS_CREDS_META/integration.env"
-  echo "apply changes"
-  echo "-----------------------------------"
-  terraform apply -var-file="$RES_AWS_CREDS_META/integration.env"
+  # echo "apply changes"
+  # echo "-----------------------------------"
+  # terraform apply -var-file="$RES_AWS_CREDS_META/integration.env"
   popd
 }
 

--- a/rc-saas/sn-private-ship-install.tf
+++ b/rc-saas/sn-private-ship-install.tf
@@ -322,31 +322,31 @@ output "ms_b_2_ip" {
 # GREEN INSTANCES
 # ---------------
 
-# # instance MS-G-1
-#resource "aws_instance" "ms_g_1" {
-#  ami = "${var.ami_us_east_1_ubuntu1604}"
-#  availability_zone = "${var.avl-zone}"
-#  instance_type = "${var.in_type_ms}"
-#  key_name = "${var.aws_key_name}"
-#  subnet_id = "${aws_subnet.sn_ship_install.id}"
-#
-#  vpc_security_group_ids = [
-#    "${aws_security_group.sg_private_ship_install.id}"]
-#
-#  root_block_device {
-#    volume_type = "gp2"
-#    volume_size = 100
-#    delete_on_termination = true
-#  }
-#
-#  tags = {
-#    Name = "ms_g_1_${var.install_version}"
-#  }
-#}
-#
-#output "ms_g_1_ip" {
-#  value = "${aws_instance.ms_g_1.private_ip}"
-#}
+# instance MS-G-1
+resource "aws_instance" "ms_g_1" {
+ ami = "${var.ami_us_east_1_ubuntu1604}"
+ availability_zone = "${var.avl-zone}"
+ instance_type = "${var.in_type_ms_x}"
+ key_name = "${var.aws_key_name}"
+ subnet_id = "${aws_subnet.sn_ship_install.id}"
+
+ vpc_security_group_ids = [
+   "${aws_security_group.sg_private_ship_install.id}"]
+
+ root_block_device {
+   volume_type = "gp2"
+   volume_size = 100
+   delete_on_termination = true
+ }
+
+ tags = {
+   Name = "ms_g_1_${var.install_version}"
+ }
+}
+
+output "ms_g_1_ip" {
+ value = "${aws_instance.ms_g_1.private_ip}"
+}
 #
 ## instance MS-G-2
 #resource "aws_instance" "ms_g_2" {

--- a/rc-saas/sn-public-ship.tf
+++ b/rc-saas/sn-public-ship.tf
@@ -214,164 +214,159 @@ resource "aws_elb" "lb_b_api_con" {
   ]
 }
 
-## ----------
-## GREEN ELBS
-## ----------
-#
-## MKTG Load balancer
-#resource "aws_elb" "lb_g_mktg" {
-#  name = "lb-g-mktg-${var.install_version}"
-#  connection_draining = true
-#  subnets = [
-#    "${aws_subnet.sn_public.id}"]
-#    security_groups = [
-#    "${aws_security_group.sg_public_lb.id}"]
-#
-#  listener {
-#    lb_port = 443
-#    lb_protocol = "ssl"
-#    instance_port = 50002
-#    instance_protocol = "tcp"
-#    ssl_certificate_id = "${var.acm_cert_arn}"
-#  }
-#
-#  health_check {
-#    healthy_threshold = 2
-#    unhealthy_threshold = 2
-#    timeout = 10
-#    target = "HTTP:50002/"
-#    interval = 30
-#  }
-#
-#  instances = [
-#    "${aws_instance.ms_g_1.id}",
-#    "${aws_instance.ms_g_2.id}"
-#  ]
-#}
-#
-## WWW Load balancer
-#resource "aws_elb" "lb_g_www" {
-#  name = "lb-g-www-${var.install_version}"
-#  connection_draining = true
-#  subnets = [
-#    "${aws_subnet.sn_public.id}"]
-#  security_groups = [
-#    "${aws_security_group.sg_public_lb.id}"]
-#
-#  listener {
-#    lb_port = 443
-#    lb_protocol = "ssl"
-#    instance_port = 50001
-#    instance_protocol = "tcp"
-#    ssl_certificate_id = "${var.acm_cert_arn}"
-#  }
-#
-#  health_check {
-#    healthy_threshold = 2
-#    unhealthy_threshold = 2
-#    timeout = 10
-#    target = "HTTP:50001/"
-#    interval = 30
-#  }
-#
-#  instances = [
-#    "${aws_instance.ms_g_1.id}",
-#    "${aws_instance.ms_g_2.id}"
-#  ]
-#}
-#
-## API Load balancer
-#resource "aws_elb" "lb_g_api" {
-#  name = "lb-g-api-${var.install_version}"
-#  connection_draining = true
-#  subnets = [
-#    "${aws_subnet.sn_public.id}"]
-#  security_groups = [
-#    "${aws_security_group.sg_public_lb.id}"]
-#
-#  listener {
-#    lb_port = 443
-#    lb_protocol = "https"
-#    instance_port = 50000
-#    instance_protocol = "http"
-#    ssl_certificate_id = "${var.acm_cert_arn}"
-#  }
-#
-#  health_check {
-#    healthy_threshold = 2
-#    unhealthy_threshold = 2
-#    timeout = 10
-#    target = "HTTP:50000/"
-#    interval = 30
-#  }
-#
-#  instances = [
-#    "${aws_instance.ms_g_1.id}",
-#    "${aws_instance.ms_g_2.id}"
-#  ]
-#}
-#
-## API INT ELB
-#resource "aws_elb" "lb_g_api_int" {
-#  name = "lb-g-api-int-${var.install_version}"
-#  connection_draining = true
-#  subnets = [
-#    "${aws_subnet.sn_public.id}"]
-#  security_groups = [
-#    "${aws_security_group.sg_public_lb.id}"]
-#
-#  listener {
-#    lb_port = 443
-#    lb_protocol = "https"
-#    instance_port = 50004
-#    instance_protocol = "http"
-#    ssl_certificate_id = "${var.acm_cert_arn}"
-#  }
-#
-#  health_check {
-#    healthy_threshold = 2
-#    unhealthy_threshold = 2
-#    timeout = 10
-#    target = "HTTP:50004/"
-#    interval = 30
-#  }
-#
-#  instances = [
-#    "${aws_instance.ms_g_1.id}",
-#    "${aws_instance.ms_g_2.id}"
-#  ]
-#}
-#
-##API CONSOLE ELB
-#resource "aws_elb" "lb_g_api_con" {
-#  name = "lb-g-api-con-${var.install_version}"
-#  connection_draining = true
-#  subnets = [
-#    "${aws_subnet.sn_public.id}"]
-#  security_groups = [
-#    "${aws_security_group.sg_public_lb.id}"]
-#
-#  listener {
-#    lb_port = 443
-#    lb_protocol = "https"
-#    instance_port = 50005
-#    instance_protocol = "http"
-#    ssl_certificate_id = "${var.acm_cert_arn}"
-#  }
-#
-#  health_check {
-#    healthy_threshold = 2
-#    unhealthy_threshold = 2
-#    timeout = 10
-#    target = "HTTP:50005/"
-#    interval = 30
-#  }
-#
-#  instances = [
-#    "${aws_instance.ms_g_1.id}",
-#    "${aws_instance.ms_g_2.id}"
-#  ]
-#}
+# ----------
+# GREEN ELBS
+# ----------
+
+# MKTG Load balancer
+resource "aws_elb" "lb_g_mktg" {
+ name = "lb-g-mktg-${var.install_version}"
+ connection_draining = true
+ subnets = [
+   "${aws_subnet.sn_public.id}"]
+   security_groups = [
+   "${aws_security_group.sg_public_lb.id}"]
+
+ listener {
+   lb_port = 443
+   lb_protocol = "ssl"
+   instance_port = 50002
+   instance_protocol = "tcp"
+   ssl_certificate_id = "${var.acm_cert_arn}"
+ }
+
+ health_check {
+   healthy_threshold = 2
+   unhealthy_threshold = 2
+   timeout = 10
+   target = "HTTP:50002/"
+   interval = 30
+ }
+
+ instances = [
+   "${aws_instance.ms_g_1.id}"
+ ]
+}
+
+# WWW Load balancer
+resource "aws_elb" "lb_g_www" {
+ name = "lb-g-www-${var.install_version}"
+ connection_draining = true
+ subnets = [
+   "${aws_subnet.sn_public.id}"]
+ security_groups = [
+   "${aws_security_group.sg_public_lb.id}"]
+
+ listener {
+   lb_port = 443
+   lb_protocol = "ssl"
+   instance_port = 50001
+   instance_protocol = "tcp"
+   ssl_certificate_id = "${var.acm_cert_arn}"
+ }
+
+ health_check {
+   healthy_threshold = 2
+   unhealthy_threshold = 2
+   timeout = 10
+   target = "HTTP:50001/"
+   interval = 30
+ }
+
+ instances = [
+   "${aws_instance.ms_g_1.id}"
+ ]
+}
+
+# API Load balancer
+resource "aws_elb" "lb_g_api" {
+ name = "lb-g-api-${var.install_version}"
+ connection_draining = true
+ subnets = [
+   "${aws_subnet.sn_public.id}"]
+ security_groups = [
+   "${aws_security_group.sg_public_lb.id}"]
+
+ listener {
+   lb_port = 443
+   lb_protocol = "https"
+   instance_port = 50000
+   instance_protocol = "http"
+   ssl_certificate_id = "${var.acm_cert_arn}"
+ }
+
+ health_check {
+   healthy_threshold = 2
+   unhealthy_threshold = 2
+   timeout = 10
+   target = "HTTP:50000/"
+   interval = 30
+ }
+
+ instances = [
+   "${aws_instance.ms_g_1.id}"
+ ]
+}
+
+# API INT ELB
+resource "aws_elb" "lb_g_api_int" {
+ name = "lb-g-api-int-${var.install_version}"
+ connection_draining = true
+ subnets = [
+   "${aws_subnet.sn_public.id}"]
+ security_groups = [
+   "${aws_security_group.sg_public_lb.id}"]
+
+ listener {
+   lb_port = 443
+   lb_protocol = "https"
+   instance_port = 50004
+   instance_protocol = "http"
+   ssl_certificate_id = "${var.acm_cert_arn}"
+ }
+
+ health_check {
+   healthy_threshold = 2
+   unhealthy_threshold = 2
+   timeout = 10
+   target = "HTTP:50004/"
+   interval = 30
+ }
+
+ instances = [
+   "${aws_instance.ms_g_1.id}"
+ ]
+}
+
+#API CONSOLE ELB
+resource "aws_elb" "lb_g_api_con" {
+ name = "lb-g-api-con-${var.install_version}"
+ connection_draining = true
+ subnets = [
+   "${aws_subnet.sn_public.id}"]
+ security_groups = [
+   "${aws_security_group.sg_public_lb.id}"]
+
+ listener {
+   lb_port = 443
+   lb_protocol = "https"
+   instance_port = 50005
+   instance_protocol = "http"
+   ssl_certificate_id = "${var.acm_cert_arn}"
+ }
+
+ health_check {
+   healthy_threshold = 2
+   unhealthy_threshold = 2
+   timeout = 10
+   target = "HTTP:50005/"
+   interval = 30
+ }
+
+ instances = [
+   "${aws_instance.ms_g_1.id}"
+ ]
+}
 
 # MSG Load balancer
 resource "aws_elb" "lb_msg" {
@@ -417,5 +412,5 @@ resource "aws_elb" "lb_msg" {
   }
 
   instances = [
-    "${aws_instance.cs_2.id}"]
+    "${aws_instance.ms_g_1.id}"]
 }

--- a/rc-saas/variables.tf
+++ b/rc-saas/variables.tf
@@ -82,6 +82,11 @@ variable "in_type_ms" {
   description = "AWS Instance type for MS machines"
 }
 
+variable "in_type_ms_x" {
+  default = "c4.xlarge"
+  description = "AWS Instance type for onebox RC machine"
+}
+
 variable "in_type_bld" {
   //make sure it is compatible with AMI, not all AMIs allow all instance types "
   default = "c3.large"


### PR DESCRIPTION
plan only

This should create 1 "ms_g" machine, using c4.xlarge.  We will use this to do a onebox install of shippable.  All of the load balancers for the "g" machines will be provisioned and point to the single instance.

once this new machine is up and running, we can switch the RC dns to point to the new load balancers, and update the shippable pipeline to perform the rc deployment on the correct machine.